### PR TITLE
v.random.strat.sampling: catch out-of-region error

### DIFF
--- a/v.random.strat.sampling.py
+++ b/v.random.strat.sampling.py
@@ -76,10 +76,13 @@ def main():
     for cl in classes:
         random_output = 'v_random_strat_sampling_%s_%s' % (cl.replace('-', '_'), str(os.getpid()))
         where_str = "%s = '%s'" % (column, cl)
-        grass.run_command(
-            'v.random', restrict=input, where=where_str, layer='1',
-            output=random_output, npoints=npoints)
-        class_outputs.append(random_output)
+        try:
+            grass.run_command(
+                'v.random', restrict=input, where=where_str, layer='1',
+                output=random_output, npoints=npoints)
+            class_outputs.append(random_output)
+        except:
+            grass.fatal("... an error occured!")
 
     # combine vector data
     grass.message("Combining separately sampled vector data...")


### PR DESCRIPTION
Before:

```
GRASS nc_spm_08_grass7/user1:v.random.strat.sampling > v.random.strat.sampling input=urbanarea column=UA_TYPE output=urbanarea_sampled_strat npoints=50
Sampling for each class separately...
WARNING: Table <v_random_strat_sampling_UC_776085> linked to vector map
         <v_random_strat_sampling_UC_776085> does not exist
ERROR: Selected areas in input vector <urbanarea> do not overlap with the
       current region
Traceback (most recent call last):
  File "/home/mneteler/.grass7/addons/scripts/v.random.strat.sampling", line 124, in <module>
    main()
  File "/home/mneteler/.grass7/addons/scripts/v.random.strat.sampling", line 79, in main
    grass.run_command(
  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 501, in run_command
    return handle_errors(returncode, result=None, args=args, kwargs=kwargs)
  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 393, in handle_errors
    raise CalledModuleError(module=module, code=code,
grass.exceptions.CalledModuleError: Module run v.random v.random restrict=urbanarea where=UA_TYPE = 'UC' layer=1 output=v_random_strat_sampling_UC_776085 npoints=50 ended with error
Process ended with non-zero return code 1. See errors in the (error) output.
```

With this PR:

```
GRASS nc_spm_08_grass7/user1:v.random.strat.sampling > v.random.strat.sampling input=urbanarea column=UA_TYPE output=urbanarea_sampled_strat npoints=50
Sampling for each class separately...
WARNING: Table <v_random_strat_sampling_UC_776475> linked to vector map
         <v_random_strat_sampling_UC_776475> does not exist
ERROR: Selected areas in input vector <urbanarea> do not overlap with the
       current region
ERROR: ... an error occured!
```

Note: the double `ERROR` isn't very nice, any better suggestion is welcome.