### PR TITLE
v.random.strat.sampling: fix white space bug

### DIFF
--- a/v.random.strat.sampling.py
+++ b/v.random.strat.sampling.py
@@ -75,6 +75,7 @@ def main():
     class_outputs = []
     for cl in classes:
         random_output = 'v_random_strat_sampling_%s_%s' % (cl.replace('-', '_'), str(os.getpid()))
+        random_output = random_output.replace(' ', '_')
         where_str = "%s = '%s'" % (column, cl)
         try:
             grass.run_command(


### PR DESCRIPTION
When using the column `NAME` of the `zipcode` map as in the new testsuite (#5) it shows a bug in the module:

When white space is in an attribute values it fails as they are internally used as a filename.
Here failing on `NEW HILL`:

```
GRASS nc_basic_spm_grass7/user1:testsuite > python3 test_v_random_strat_sampling.py

Sampling for each class separately...
Generating points...
 100%
Building topology for vector map
<v_random_strat_sampling_CREEDMOOR_797762@user1>...
Registering primitives...
Generating points...
 100%
Building topology for vector map
...
<v_random_strat_sampling_APEX_797762@user1>...
Registering primitives...
Generating points...
 100%
Building topology for vector map
<v_random_strat_sampling_GARNER_797762@user1>...
Registering primitives...
WARNING: Illegal filename <v_random_strat_sampling_NEW HILL_797762>.
         Character < > not allowed.
WARNING: Illegal vector map name <v_random_strat_sampling_NEW HILL_797762>.
         Character ' ' not allowed.
ERROR: Unable to create vector map: <v_random_strat_sampling_NEW
       HILL_797762> is not SQL compliant
Traceback (most recent call last):
  File "/home/mneteler/.grass7/addons/scripts/v.random.strat.sampling", line 122, in <module>
    main()
  File "/home/mneteler/.grass7/addons/scripts/v.random.strat.sampling", line 79, in main
    grass.run_command(
  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 501, in run_command
    return handle_errors(returncode, result=None, args=args, kwargs=kwargs)
  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 393, in handle_errors
    raise CalledModuleError(module=module, code=code,
grass.exceptions.CalledModuleError: Module run v.random v.random restrict=zipcodes where=NAME = 'NEW HILL' layer=1 output=v_random_strat_sampling_NEW HILL_797762 npoints=50 ended with error
Process ended with non-zero return code 1. See errors in the (error) output.

F
======================================================================
FAIL: test_points (__main__.Testdivide)
Test divide points
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/gunittest/case.py", line 1153, in assertModule
    module.run()
  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/pygrass/modules/interface/module.py", line 773, in run
    self.wait()
grass.exceptions.CalledModuleError: Module run v.random.strat.sampling v.random.strat.sampling input=zipcodes column=NAME npoints=50 output=training ended with error
Process ended with non-zero return code 1. See the following errors:
b'Sampling for each class separately...\nGenerating points...\n   0%\x08\x08\x08\x08\x08   6%\x08\x08\x08\x08\x08  12%\x08\x08\x08\x08\x08  18%\x08\x08\x08\x08\x08  24%\x08\x08\x08\x08\x08  30%\x08\x08\x08\x08\x08  36%\x08\x08\x08\x08\x08  42%\x08\x08\x08\x08\x08  48%\x08\x08\x08\x08\x08  54%\x08\x08\x08\x08\x08  60%\x08\x08\x08\x08\x08  66%\x08\x08\x08\x08\x08  72%\x08\x08\x08\x08\x08  78%\x08\x08\x08\x08\x08  84%\x08\x08\x08\x08\x08  90%\x08\x08\x08\x08\x08  96%\x08\x08\x08\x08\x08 100%\x08\x08\x08\x08\x08\nBuilding topology for vector 
...
Building topology for vector map\n<v_random_strat_sampling_GARNER_797762@user1>...\nRegistering primitives...\n\rWARNING: Illegal filename <v_random_strat_sampling_NEW HILL_797762>.\n         Character < > not allowed.\nWARNING: Illegal vector map name <v_random_strat_sampling_NEW HILL_797762>.\n         Character \' \' not allowed.\nERROR: Unable to create vector map: <v_random_strat_sampling_NEW\n       HILL_797762> is not SQL compliant\nTraceback (most recent call last):\n  File "/home/mneteler/.grass7/addons/scripts/v.random.strat.sampling", line 122, in <module>\n    main()\n  File "/home/mneteler/.grass7/addons/scripts/v.random.strat.sampling", line 79, in main\n    grass.run_command(\n  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 501, in run_command\n    return handle_errors(returncode, result=None, args=args, kwargs=kwargs)\n  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 393, in handle_errors\n    raise CalledModuleError(module=module, code=code,\ngrass.exceptions.CalledModuleError: Module run v.random v.random restrict=zipcodes where=NAME = \'NEW HILL\' layer=1 output=v_random_strat_sampling_NEW HILL_797762 npoints=50 ended with error\nProcess ended with non-zero return code 1. See errors in the (error) output.\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mneteler/software/mundialis_repos/v.random.strat.sampling/testsuite/test_v_random_strat_sampling.py", line 35, in test_points
    self.assertModule('v.random.strat.sampling', input=self.invect, column='NAME',
  File "/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python/grass/gunittest/case.py", line 1168, in assertModule
    self.fail(self._formatMessage(msg, stdmsg))
AssertionError: Running <v.random.strat.sampling> module ended with non-zero return code (1)
Called: v.random_strat_sampling(input='zipcodes', column='NAME', output='training', npoints=50)
```

--> WARNING: Illegal filename <v_random_strat_sampling_NEW HILL_797762>.
         Character < > not allowed.

This PR fixes the issue by changing white space to underscore.